### PR TITLE
MaxMind requires HTTPS for database downloads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,9 @@ archive: package
 
 download-data:
 	@mkdir -p data
-	@wget -P data/ http://geolite.maxmind.com/download/geoip/database/GeoIPv6.dat.gz
-	@wget -P data/ http://geolite.maxmind.com/download/geoip/database/GeoLiteCityv6-beta/GeoLiteCityv6.dat.gz
-	@wget -P data/ http://download.maxmind.com/download/geoip/database/asnum/GeoIPASNumv6.dat.gz
+	@wget -P data/ https://geolite.maxmind.com/download/geoip/database/GeoIPv6.dat.gz
+	@wget -P data/ https://geolite.maxmind.com/download/geoip/database/GeoLiteCityv6-beta/GeoLiteCityv6.dat.gz
+	@wget -P data/ https://download.maxmind.com/download/geoip/database/asnum/GeoIPASNumv6.dat.gz
 
 test-go:
 	@touch xunit.xml


### PR DESCRIPTION
MaxMind will be requiring HTTPS for all database download requests starting in March 2024.

See [this release note](https://dev.maxmind.com/geoip/release-notes/2023#api-policies---temporary-enforcement-on-october-17-2023).